### PR TITLE
Benchmark tool fixes + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,4 +149,4 @@ Example command:
 python3 helper_scripts/benchmark.py --duration 30 --output <output directory> --merchants <merchant A command> <merchant B command> --consumer <consumer command>
 ```
 This starts the whole platform and two merchants to compete against each other for 30 minutes.
-Run `python3 --help` to see all arguments.
+Run `python3 helper_scripts/benchmark.py --help` to see all arguments.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ First, the analytics container is expected to be stopped after a short moment - 
 
 ### Continuous Deployment
 
-For the production environment within the HPI cluster, we use [Codeship](http://codeship.com/) for Continuous Integration (CI) & Continuous Deployment (CD). In each repository, there is a _config/deploy/_ folder containing deployment specifications which are executed via [capistrano](https://github.com/capistrano/capistrano).
+For the production environment within the HPI cluster, we use [Codeship](https://codeship.com/) for Continuous Integration (CI) & Continuous Deployment (CD). In each repository, there is a _config/deploy/_ folder containing deployment specifications which are executed via [capistrano](https://github.com/capistrano/capistrano).
 
 "Capistrano is a framework for building automated deployment scripts. Although Capistrano itself is written in Ruby, it can easily be used to deploy projects of any language or framework, be it Rails, Java, or PHP. [..] When you run *cap*, Capistrano dutifully connects to your server(s) via SSH and executes the steps necessary to deploy your project. You can define those steps yourself by writing Rake tasks, or by using pre-built task libraries provided by the Capistrano community." [quote](https://github.com/capistrano/capistrano).
 
@@ -130,13 +130,23 @@ More details regarding this VPN configuration may be found under _config/openvpn
 ### Native
 For details regarding the deployment of the component, we kindly refer to the deployment section of the microservice specific README.md file. The links can be found above.
 
-## Setup
+## Run Pricewars
 
-After marketplace, producer and logger are in place, one may
+After starting the Pricewars platform with `docker-compose up`, it can be controlled with the [Management UI](http://management-ui)
 
-1. Register Merchants via UI (Menu section: Deployment)
-2. Alter available product via UI (Menu section: Config/Producer)
-3. Start Merchants via UI (Menu section: Config/Merchant)
-4. Start Consumer via UI (Menu section: Config/Consumer)
-5. View Results via UI (Menu section: Dashboard)
-6. In case of performance issues, one may debug bottlenecks with munin graphs (Menu section: Links/Munin)
+1. \[Optional] Configure available products in the [Config/Producer section](http://management-ui/index.html#/config/producer)
+2. Start the [Consumer](http://management-ui/index.html#/config/consumer)
+3. Merchants are trading products now. The [Dashboard](http://management-ui/index.html#/dashboard/overview) shows graphs about sales, profits and more.
+
+## Benchmark Tool
+
+You can run a benchmark on the Pricewars platform with the benchmark tool [benchmark.py](helper_scripts/benchmark.py).
+This tool allows to run the platform in a given configuration for a specific time period.
+Afterwards, results of this run are written to the output directory.
+
+Example command:
+```
+python3 helper_scripts/benchmark.py --duration 30 --output <output directory> --merchants <merchant A command> <merchant B command> --consumer <consumer command>
+```
+This starts the whole platform and two merchants to compete against each other for 30 minutes.
+Run `python3 --help` to see all arguments.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ git clone git@github.com:hpi-epic/pricewars.git --recurse-submodules
 cd pricewars
 docker-compose up
 ```
+When running `docker-compose up` for the first time, all docker images must be built.
+This will take 30 minutes to one hour depending on your internet speed.
+
 
 #### Adjust some DNS settings:
 If you want to use the management-ui add the following lines to your host file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,6 @@ services:
       - kafka-reverse-proxy
       - marketplace
       - producer
-      - consumer
 
   marketplace:
     build: ./marketplace

--- a/helper_scripts/benchmark.py
+++ b/helper_scripts/benchmark.py
@@ -37,7 +37,7 @@ def dump_topic(topic, output_dir):
     consumer = KafkaConsumer(topic,
                              bootstrap_servers='kafka:9092',
                              value_deserializer=lambda m: json.loads(m.decode('utf-8')),
-                             consumer_timeout_ms=100,
+                             consumer_timeout_ms=2000,
                              auto_offset_reset='earliest')
 
     events = [message.value for message in consumer]
@@ -102,7 +102,9 @@ def main():
     os.mkdir(output_dir)
     clear_containers(pricewars_dir)
 
-    with PopenWrapper(['docker-compose', 'up'], cwd=pricewars_dir):
+    core_services = ['producer', 'marketplace', 'management-ui', 'analytics', 'flink-taskmanager', 'flink-jobmanager',
+                     'kafka-reverse-proxy', 'kafka', 'zookeeper', 'redis', 'postgres']
+    with PopenWrapper(['docker-compose', 'up'] + core_services, cwd=pricewars_dir):
         # wait until the marketplace service is up and running
         wait_for_marketplace()
 


### PR DESCRIPTION
### Benchmark Tools changes
The benchmark tool starts no longer merchants and consumers from the docker-compose file. This way, they cannot interfere with merchants and consumers that are directly started by the benchmark tool.
I removed the consumer from the management UI's dependencies in the docker-compose file to be able to start the management UI without starting the consumer (docker-compose automatically starts service dependencies).

An alternative solution would be to split the compose file into core-services and all-services. And the benchmark tool only uses the core_services file. But I couldn't find a good solution for this.

Fixed a bug that caused missing data in the kafka dumps. The short timeout stopped the iteration even if there are still events pending.

### README updates
* Add warning about long docker image building times for the first execution
* Update steps to configure the platform. Add links to the mentioned UI sections
* Add section about the benchmark tool