### PR TITLE
Make merchant robuster by restarting it in case it crashes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,9 +151,10 @@ services:
 
   merchant:
     build: ./merchant
+    restart: always
     ports:
       - "5003:5003"
-    command: python3 -u merchant.py --port 5000 --strategy "Two Bound"
+    command: python3 -u merchant.py --port 5003 --strategy "Two Bound"
     volumes:
       - ./merchant:/merchant
     depends_on:


### PR DESCRIPTION
The merchant sometimes crashes. This change auto-restarts the Docker container when that happens. I also corrected the port, so that it matches the exposed port.

//cc @frederike-ramin @KBorchar 