### PR TITLE
Correct outdated clean_start helper scripts

### DIFF
--- a/helper_scripts/clean_start.sh
+++ b/helper_scripts/clean_start.sh
@@ -1,48 +1,6 @@
 #!/bin/bash
-# This file is intended to be used in case of docker problems. It stops and 
+# This file is intended to be used in case of docker problems. It stops and
 # removes all docker containers, followed by a docker-compose up.
-# (thanks to @carlambroselli).
-rm -rf docker-mounts/*
 
-docker stop masterprojectpricewars_management-ui_1
-docker stop masterprojectpricewars_merchant-simple-competition-logic1_1
-docker stop masterprojectpricewars_merchant-machine-learning_1
-docker stop masterprojectpricewars_merchant-sample-fix-price_1
-docker stop masterprojectpricewars_merchant-sample-second-cheapest_1
-docker stop masterprojectpricewars_merchant-sample-cheapest_1
-docker stop masterprojectpricewars_merchant-sample-random-third_1
-docker stop masterprojectpricewars_merchant-simple-competition-logic2_1
-docker stop masterprojectpricewars_merchant-sample-two-bound_1
-docker stop masterprojectpricewars_consumer_1
-docker stop masterprojectpricewars_marketplace_1
-docker stop masterprojectpricewars_flink-taskmanager_1
-docker stop masterprojectpricewars_kafka-reverse-proxy_1
-docker stop masterprojectpricewars_flink-jobmanager_1
-docker stop masterprojectpricewars_producer_1
-docker stop masterprojectpricewars_kafka_1
-docker stop masterprojectpricewars_postgres_1
-docker stop masterprojectpricewars_zookeeper_1
-docker stop masterprojectpricewars_redis_1
-docker stop masterprojectpricewars_analytics_1
-
-docker rm masterprojectpricewars_management-ui_1
-docker rm masterprojectpricewars_merchant-simple-competition-logic1_1
-docker rm masterprojectpricewars_merchant-machine-learning_1
-docker rm masterprojectpricewars_merchant-sample-fix-price_1
-docker rm masterprojectpricewars_merchant-sample-second-cheapest_1
-docker rm masterprojectpricewars_merchant-sample-cheapest_1
-docker rm masterprojectpricewars_merchant-sample-random-third_1
-docker rm masterprojectpricewars_merchant-simple-competition-logic2_1
-docker rm masterprojectpricewars_merchant-sample-two-bound_1
-docker rm masterprojectpricewars_consumer_1
-docker rm masterprojectpricewars_marketplace_1
-docker rm masterprojectpricewars_flink-taskmanager_1
-docker rm masterprojectpricewars_kafka-reverse-proxy_1
-docker rm masterprojectpricewars_flink-jobmanager_1
-docker rm masterprojectpricewars_producer_1
-docker rm masterprojectpricewars_kafka_1
-docker rm masterprojectpricewars_postgres_1
-docker rm masterprojectpricewars_zookeeper_1
-docker rm masterprojectpricewars_redis_1
-docker rm masterprojectpricewars_analytics_1
+docker-compose rm -v -s -f
 docker-compose up

--- a/helper_scripts/clean_start.sh
+++ b/helper_scripts/clean_start.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# This file is intended to be used in case of docker problems. It stops and
-# removes all docker containers, followed by a docker-compose up.
-
-docker-compose rm -v -s -f
-docker-compose up

--- a/helper_scripts/full_clean_start.sh
+++ b/helper_scripts/full_clean_start.sh
@@ -1,67 +1,7 @@
 #!/bin/bash
 # This file is intended to be used in case of severe docker problems. It stops
-# and removes all docker containers, then fully removes the docker images
-# (leading to a time consuming rebuild), followed by a docker-compose up.
-# (thanks to @carlambroselli).
-rm -rf docker-mounts/*
+# and removes all docker containers, rebuilds them and executes docker-compose up
+# (leading to a time consuming rebuild).
 
-docker stop masterprojectpricewars_management-ui_1
-docker stop masterprojectpricewars_merchant-simple-competition-logic1_1
-docker stop masterprojectpricewars_merchant-machine-learning_1
-docker stop masterprojectpricewars_merchant-sample-fix-price_1
-docker stop masterprojectpricewars_merchant-sample-second-cheapest_1
-docker stop masterprojectpricewars_merchant-sample-cheapest_1
-docker stop masterprojectpricewars_merchant-sample-random-third_1
-docker stop masterprojectpricewars_merchant-simple-competition-logic2_1
-docker stop masterprojectpricewars_merchant-sample-two-bound_1
-docker stop masterprojectpricewars_consumer_1
-docker stop masterprojectpricewars_marketplace_1
-docker stop masterprojectpricewars_flink-taskmanager_1
-docker stop masterprojectpricewars_kafka-reverse-proxy_1
-docker stop masterprojectpricewars_flink-jobmanager_1
-docker stop masterprojectpricewars_producer_1
-docker stop masterprojectpricewars_kafka_1
-docker stop masterprojectpricewars_postgres_1
-docker stop masterprojectpricewars_zookeeper_1
-docker stop masterprojectpricewars_redis_1
-docker stop masterprojectpricewars_analytics_1
-
-docker-compose down
-
-docker rm masterprojectpricewars_management-ui_1
-docker rm masterprojectpricewars_merchant-simple-competition-logic1_1
-docker rm masterprojectpricewars_merchant-machine-learning_1
-docker rm masterprojectpricewars_merchant-sample-fix-price_1
-docker rm masterprojectpricewars_merchant-sample-second-cheapest_1
-docker rm masterprojectpricewars_merchant-sample-cheapest_1
-docker rm masterprojectpricewars_merchant-sample-random-third_1
-docker rm masterprojectpricewars_merchant-simple-competition-logic2_1
-docker rm masterprojectpricewars_merchant-sample-two-bound_1
-docker rm masterprojectpricewars_consumer_1
-docker rm masterprojectpricewars_marketplace_1
-docker rm masterprojectpricewars_flink-taskmanager_1
-docker rm masterprojectpricewars_kafka-reverse-proxy_1
-docker rm masterprojectpricewars_flink-jobmanager_1
-docker rm masterprojectpricewars_producer_1
-docker rm masterprojectpricewars_kafka_1
-docker rm masterprojectpricewars_postgres_1
-docker rm masterprojectpricewars_zookeeper_1
-docker rm masterprojectpricewars_redis_1
-docker rm masterprojectpricewars_analytics_1
-
-docker rmi pricewars/management-ui
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/merchant
-docker rmi pricewars/consumer
-docker rmi pricewars/marketplace
-docker rmi pricewars/kafka-reverse-proxy
-docker rmi pricewars/producer
-docker rmi pricewars/analytics
-
-docker-compose up
+docker-compose rm -v -s -f
+docker-compose up --build

--- a/helper_scripts/full_clean_start.sh
+++ b/helper_scripts/full_clean_start.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# This file is intended to be used in case of severe docker problems. It stops
-# and removes all docker containers, rebuilds them and executes docker-compose up
-# (leading to a time consuming rebuild).
-
-docker-compose rm -v -s -f
-docker-compose up --build


### PR DESCRIPTION
I am not 100% sure, but I think my simple commands achieve the same results the scripts were supposed to do achieve. Additionally, the scripts contained the old name `masterprojectpricewars`, so they didn't work anyways.

//cc @frederike-ramin @KBorchar 