### PR TITLE
Benchmark Tool: Use localhost URLs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,17 +18,20 @@ services:
       - "2181:2181"
 
   kafka:
-    image: wurstmeister/kafka:latest
+    image: wurstmeister/kafka:1.1.0
     ports:
       - "9092:9092"
+      - "9093:9093"
     environment:
-      - KAFKA_ADVERTISED_HOST_NAME=kafka
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - KAFKA_DELETE_TOPIC_ENABLE=true
-      - KAFKA_LOG_DIRS=/kafka/kafka-logs
-      - KAFKA_LOG_RETENTION_HOURS=-1
-      - LOG4J_LOGGER_KAFKA=WARN
-      - LOG4J_LOGGER_ORG_APACHE_ZOOKEEPER=WARN
+      KAFKA_ADVERTISED_LISTENERS: INSIDE://kafka:9092,OUTSIDE://192.168.47.1:9093
+      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LOG_DIRS: /kafka/kafka-logs
+      KAFKA_LOG_RETENTION_HOURS: -1
+      LOG4J_LOGGER_KAFKA: WARN
+      LOG4J_LOGGER_ORG_APACHE_ZOOKEEPER: WARN
     depends_on:
       - zookeeper
 


### PR DESCRIPTION
The benchmark tool uses `localhost` instead of the hostnames `marketplace`, `kafka` and `consumer`.
This is one step needed to remove our entries in the hosts file. The URLs can be configured with start parameters.

Kafka now uses two listeners.
`kafka:9092` for the docker-internal network, and
`192.168.47.1:9093` for the external network. `192.168.47.1` is the IP of the docker host.

Also this PR updates the marketplace submodule.
It might be necessary to rebuild the Zookeeper Container (e.g. with `docker-compose rm`). 