### PR TITLE
Benchmark Tool: Plot profit and revenue per minute

### DIFF
--- a/helper_scripts/analyze.py
+++ b/helper_scripts/analyze.py
@@ -55,7 +55,7 @@ def analyze_kafka_dump(directory):
 
 def parse_timestamps(events):
     for event in events:
-        # TODO: ues better conversion; strptime discards timezone
+        # TODO: use better conversion; strptime discards timezone
         try:
             event['timestamp'] = datetime.datetime.strptime(event['timestamp'], '%Y-%m-%dT%H:%M:%S.%fZ')
         except ValueError:

--- a/helper_scripts/analyze.py
+++ b/helper_scripts/analyze.py
@@ -70,6 +70,7 @@ def create_inventory_graph(directory, merchant_id_mapping):
         dates, inventory_levels = zip(*((event['timestamp'], event['level']) for event
             in inventory_events if event['merchant_id'] == merchant_id))
         ax.step(dates, inventory_levels, where='post', label=merchant_id_mapping[merchant_id])
+    plt.xlabel('Time')
     plt.ylabel('Inventory Level')
     fig.legend()
     fig.autofmt_xdate()
@@ -82,7 +83,8 @@ def create_profit_per_minute_graph(directory, merchant_id_mapping):
     for merchant_id in merchant_id_mapping:
         dates, profits = zip(*((event['timestamp'], event['profit']) for event
             in events if event['merchant_id'] == merchant_id))
-        ax.bar(dates, profits, width=0.00003, label=merchant_id_mapping[merchant_id])
+        ax.plot(dates, profits, label=merchant_id_mapping[merchant_id])
+    plt.xlabel('Time')
     plt.ylabel('Profit per Minute')
     fig.legend()
     fig.autofmt_xdate()
@@ -95,7 +97,8 @@ def create_revenue_per_minute_graph(directory, merchant_id_mapping):
     for merchant_id in merchant_id_mapping:
         dates, revenues = zip(*((event['timestamp'], event['revenue']) for event
             in events if event['merchant_id'] == merchant_id))
-        ax.bar(dates, revenues, width=0.00003, label=merchant_id_mapping[merchant_id])
+        ax.plot(dates, revenues, label=merchant_id_mapping[merchant_id])
+    plt.xlabel('Time')
     plt.ylabel('Revenue per Minute')
     fig.legend()
     fig.autofmt_xdate()

--- a/helper_scripts/benchmark.py
+++ b/helper_scripts/benchmark.py
@@ -49,9 +49,12 @@ def dump_topic(topic, output_dir, kafka_host):
 def dump_kafka(output_dir, kafka_host):
     kafka_dir = os.path.join(output_dir, 'kafka')
     os.mkdir(kafka_dir)
-    topics = ['buyOffer', 'holding_cost', 'marketSituation', 'producer']
+    topics = KafkaConsumer(bootstrap_servers=kafka_host).topics()
     for topic in topics:
-        dump_topic(topic, kafka_dir, kafka_host)
+        try:
+            dump_topic(topic, kafka_dir, kafka_host)
+        except json.decoder.JSONDecodeError:
+            print('Failed to dump kafka topic', topic)
 
 
 def save_merchant_id_mapping(output_dir, marketplace_url):


### PR DESCRIPTION
The benchmark tool plot two new graphs: Profit per minute and revenue per minute.
After running the simulation for 15 minutes, the graphs look like this:

![profit_per_minute](https://user-images.githubusercontent.com/7498573/42089864-61a8f848-7b9f-11e8-8366-c1248157896b.png)
![revenue_per_minute](https://user-images.githubusercontent.com/7498573/42089866-6519af0e-7b9f-11e8-8180-b007e01dbffb.png)

At first, I tried bar charts but they are hard to look at.

Other changes:
* All available kafka topics are saved to disk
*  Use the inventory_level topic instead of computing the levels by hand