### PR TITLE
Change merchant restart behavior

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
 
   merchant:
     build: ./merchant
-    restart: always
+    restart: on-failure:5
     ports:
       - "5003:5003"
     command: python3 -u merchant.py --port 5003 --strategy "Two Bound"


### PR DESCRIPTION
The configuration `restart: always` starts the container after the start of the docker daemon.
Example: If I restart my laptop, the merchant will be started.
I changed the behavior to `on-failure` with 5 restart attempts.