### PR TITLE
Rename submodule mgmt-ui to management-ui

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	path = producer
 	url = https://github.com/hpi-epic/pricewars-producer.git
 [submodule "mgmt-ui"]
-	path = mgmt-ui
+	path = management-ui
 	url = git@github.com:hpi-epic/pricewars-mgmt-ui.git
 [submodule "kafka-reverse-proxy"]
 	path = kafka-reverse-proxy

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 [submodule "producer"]
 	path = producer
 	url = https://github.com/hpi-epic/pricewars-producer.git
-[submodule "mgmt-ui"]
+[submodule "management-ui"]
 	path = management-ui
 	url = git@github.com:hpi-epic/pricewars-mgmt-ui.git
 [submodule "kafka-reverse-proxy"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - ./analytics:/export
 
   management-ui:
-    build: ./mgmt-ui
+    build: ./management-ui
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
When typing in console it's hard to remember if it was mgmt, mngt or mgmasdf.
Using the whole word is more clear and easier to type.